### PR TITLE
[MSP430] Improve support for 'interrupt' attribute

### DIFF
--- a/src/llvm/test/CodeGen/MSP430/2009-12-21-FrameAddr.ll
+++ b/src/llvm/test/CodeGen/MSP430/2009-12-21-FrameAddr.ll
@@ -3,7 +3,7 @@
 target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8"
 target triple = "msp430-unknown-linux-gnu"
 
-define msp430_intrcc void @foo() nounwind {
+define msp430_intrcc void @foo() nounwind #0 {
 entry:
 	%fa = call i8* @llvm.frameaddress(i32 0)
 	store i8 0, i8* %fa
@@ -11,3 +11,5 @@ entry:
 }
 
 declare i8* @llvm.frameaddress(i32)
+
+attributes #0 = { noinline nounwind optnone "interrupt"="2" }

--- a/src/llvm/test/CodeGen/MSP430/fp.ll
+++ b/src/llvm/test/CodeGen/MSP430/fp.ll
@@ -27,3 +27,5 @@ define msp430_intrcc void @fpb_alloced() #0 {
   call void asm sideeffect "nop", "r"(i8 0)
   ret void
 }
+
+attributes #0 = { noinline nounwind optnone "interrupt"="2" }

--- a/src/llvm/test/CodeGen/MSP430/interrupt.ll
+++ b/src/llvm/test/CodeGen/MSP430/interrupt.ll
@@ -13,6 +13,9 @@ target triple = "msp430-generic-generic"
 ; instruction RETI, which restores the SR register and branches to the PC where
 ; the interrupt occurred.
 
+; CHECK:      .section	__interrupt_vector_2,"ax",@progbits
+; CHECK-NEXT:	.short	ISR
+
 @g = global float 0.0
 
 define msp430_intrcc void @ISR() #0 {
@@ -47,3 +50,4 @@ entry:
   ret void
 }
 
+attributes #0 = { noinline nounwind optnone "interrupt"="2" }

--- a/src/llvm/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/src/llvm/tools/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -284,6 +284,10 @@ def warn_riscv_interrupt_attribute : Warning<
    "RISC-V 'interrupt' attribute only applies to functions that have "
    "%select{no parameters|a 'void' return type}0">,
    InGroup<IgnoredAttributes>;
+def warn_msp430_interrupt_attribute : Warning<
+   "MSP430 'interrupt' attribute only applies to functions that have "
+   "%select{no parameters|a 'void' return type}0">,
+   InGroup<IgnoredAttributes>;
 def warn_unused_parameter : Warning<"unused parameter %0">,
   InGroup<UnusedParameter>, DefaultIgnore;
 def warn_unused_variable : Warning<"unused variable %0">,

--- a/src/llvm/tools/clang/lib/CodeGen/TargetInfo.cpp
+++ b/src/llvm/tools/clang/lib/CodeGen/TargetInfo.cpp
@@ -6763,21 +6763,19 @@ void MSP430TargetCodeGenInfo::setTargetAttributes(
   if (GV->isDeclaration())
     return;
   if (const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D)) {
-    if (const MSP430InterruptAttr *attr = FD->getAttr<MSP430InterruptAttr>()) {
-      // Handle 'interrupt' attribute:
-      llvm::Function *F = cast<llvm::Function>(GV);
+    const MSP430InterruptAttr *Attr = FD->getAttr<MSP430InterruptAttr>();
+    if (!Attr)
+      return;
 
-      // Step 1: Set ISR calling convention.
-      F->setCallingConv(llvm::CallingConv::MSP430_INTR);
+    // Handle 'interrupt' attribute:
+    llvm::Function *F = cast<llvm::Function>(GV);
 
-      // Step 2: Add attributes goodness.
-      F->addFnAttr(llvm::Attribute::NoInline);
+    // Step 1: Set ISR calling convention.
+    F->setCallingConv(llvm::CallingConv::MSP430_INTR);
 
-      // Step 3: Emit ISR vector alias.
-      unsigned Num = attr->getNumber() / 2;
-      llvm::GlobalAlias::create(llvm::Function::ExternalLinkage,
-                                "__isr_" + Twine(Num), F);
-    }
+    // Step 2: Add attributes goodness.
+    F->addFnAttr(llvm::Attribute::NoInline);
+    F->addFnAttr("interrupt", llvm::utostr(Attr->getNumber()));
   }
 }
 

--- a/src/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/src/llvm/tools/clang/lib/Sema/SemaDeclAttr.cpp
@@ -5251,6 +5251,27 @@ static void handleARMInterruptAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
 }
 
 static void handleMSP430InterruptAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
+  // MSP430 'interrupt' attribute is applied to
+  // a function with no parameters and void return type
+  if (!isFunctionOrMethod(D)) {
+    S.Diag(D->getLocation(), diag::warn_attribute_wrong_decl_type)
+        << "'interrupt'" << ExpectedFunctionOrMethod;
+    return;
+  }
+
+  if (hasFunctionProto(D) && getFunctionOrMethodNumParams(D) != 0) {
+    S.Diag(D->getLocation(), diag::warn_msp430_interrupt_attribute)
+        << 0;
+    return;
+  }
+
+  if (!getFunctionOrMethodResultType(D)->isVoidType()) {
+    S.Diag(D->getLocation(), diag::warn_msp430_interrupt_attribute)
+        << 1;
+    return;
+  }
+
+  // The attribute takes one integer argument
   if (!checkAttributeNumArgs(S, AL, 1))
     return;
 
@@ -5260,8 +5281,6 @@ static void handleMSP430InterruptAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
     return;
   }
 
-  // FIXME: Check for decl - it should be void ()(void).
-
   Expr *NumParamsExpr = static_cast<Expr *>(AL.getArgAsExpr(0));
   llvm::APSInt NumParams(32);
   if (!NumParamsExpr->isIntegerConstantExpr(NumParams, S.Context)) {
@@ -5270,9 +5289,9 @@ static void handleMSP430InterruptAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
         << NumParamsExpr->getSourceRange();
     return;
   }
-
+  // The argument should be in range 0..63
   unsigned Num = NumParams.getLimitedValue(255);
-  if ((Num & 1) || Num > 30) {
+  if (Num > 63) {
     S.Diag(AL.getLoc(), diag::err_attribute_argument_out_of_bounds)
         << AL << (int)NumParams.getSExtValue()
         << NumParamsExpr->getSourceRange();

--- a/src/llvm/tools/clang/test/CodeGen/attr-msp430.c
+++ b/src/llvm/tools/clang/test/CodeGen/attr-msp430.c
@@ -1,0 +1,10 @@
+// RUN: %clang_cc1 -triple msp430-unknown-unknown -emit-llvm < %s| FileCheck %s
+
+__attribute__((interrupt(1))) void foo(void) {}
+// CHECK: @llvm.used
+// CHECK-SAME: @foo
+
+// CHECK: define msp430_intrcc void @foo() #0
+// CHECK: attributes #0
+// CHECK-SAME: noinline
+// CHECK-SAME: "interrupt"="1"

--- a/src/llvm/tools/clang/test/Sema/attr-msp430.c
+++ b/src/llvm/tools/clang/test/Sema/attr-msp430.c
@@ -1,6 +1,13 @@
 // RUN: %clang_cc1 -triple msp430-unknown-unknown -fsyntax-only -verify %s
 
-int i;
-void f(void) __attribute__((interrupt(i))); /* expected-error {{'interrupt' attribute requires an integer constant}} */
+__attribute__((interrupt(1))) int t; // expected-warning {{'interrupt' attribute only applies to functions}}
 
-void f2(void) __attribute__((interrupt(12)));
+int i;
+__attribute__((interrupt(i))) void f(void); // expected-error {{'interrupt' attribute requires an integer constant}}
+__attribute__((interrupt(1, 2))) void f2(void); // expected-error {{'interrupt' attribute takes one argument}}
+__attribute__((interrupt(1))) int f3(void); // expected-warning {{MSP430 'interrupt' attribute only applies to functions that have a 'void' return type}}
+__attribute__((interrupt(1))) void f4(int a); // expected-warning {{MSP430 'interrupt' attribute only applies to functions that have no parameters}}
+__attribute__((interrupt(64))) void f5(void); // expected-error {{'interrupt' attribute parameter 64 is out of bounds}}
+
+__attribute__((interrupt(0))) void f6(void);
+__attribute__((interrupt(63))) void f7(void);


### PR DESCRIPTION
* Allow to accept as an argument constants in range 0..63.
* Add more diagnostics.
* Generate function attribute 'interrupt'='X' instead of aliases.
* Emit a separate section for interrupt vectors.
* Add more tests.