### PR TITLE
Fix encodeInstruction() failure on big endian hosts

### DIFF
--- a/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp
+++ b/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp
@@ -91,12 +91,11 @@ void MSP430MCCodeEmitter::encodeInstruction(const MCInst &MI, raw_ostream &OS,
   Offset = 2;
 
   uint64_t BinaryOpCode = getBinaryCodeForInstr(MI, Fixups, STI);
-  const uint16_t *Words = reinterpret_cast<uint16_t const *>(&BinaryOpCode);
   size_t WordCount = Size / 2;
 
   for (size_t i = 0; i < WordCount; ++i) {
-    uint16_t Word = Words[i];
-    support::endian::write(OS, Word, support::little);
+    support::endian::write(OS, (uint16_t)BinaryOpCode, support::little);
+    BinaryOpCode >>= 16;
   }
 }
 


### PR DESCRIPTION
Tested under `qemu-ppc64`.
Should fix http://lab.llvm.org:8011/builders/clang-ppc64be-linux/builds/26287.