### PR TITLE
[MSP430] Use R_MSP430_16_BYTE type for FK_Data_2 fixup

### DIFF
--- a/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430ELFObjectWriter.cpp
+++ b/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430ELFObjectWriter.cpp
@@ -34,7 +34,7 @@ protected:
     // Translate fixup kind to ELF relocation type.
     switch ((unsigned)Fixup.getKind()) {
     case FK_Data_1:                   return ELF::R_MSP430_8;
-    case FK_Data_2:                   return ELF::R_MSP430_16;
+    case FK_Data_2:                   return ELF::R_MSP430_16_BYTE;
     case FK_Data_4:                   return ELF::R_MSP430_32;
     case MSP430::fixup_32:            return ELF::R_MSP430_32;
     case MSP430::fixup_10_pcrel:      return ELF::R_MSP430_10_PCREL;

--- a/src/llvm/test/MC/MSP430/reloc.s
+++ b/src/llvm/test/MC/MSP430/reloc.s
@@ -1,22 +1,33 @@
 ; RUN: llvm-mc -triple msp430 -show-encoding < %s | FileCheck %s
+; RUN: llvm-mc -filetype=obj -triple msp430 < %s | llvm-readobj -r \
+; RUN:   | FileCheck -check-prefix=RELOC %s
 
          mov    disp+2(r8), r15
 ; CHECK: mov    disp+2(r8), r15 ; encoding: [0x1f,0x48,A,A]
 ; CHECK:                        ;   fixup A - offset: 2, value: disp+2, kind: fixup_16_byte
+; RELOC: R_MSP430_16_BYTE disp 0x2
 
          mov    disp+2, r15
 ; CHECK: mov    disp+2, r15     ; encoding: [0x1f,0x40,A,A]
 ; CHECK:                        ;   fixup A - offset: 2, value: disp+2, kind: fixup_16_pcrel_byte
+; RELOC: R_MSP430_16_PCREL_BYTE disp 0x2
 
          mov    &disp+2, r15
 ; CHECK: mov    &disp+2, r15    ; encoding: [0x1f,0x42,A,A]
 ; CHECK:                        ;   fixup A - offset: 2, value: disp+2, kind: fixup_16
+; RELOC: R_MSP430_16_BYTE disp 0x2
 
          mov    disp, disp+2
 ; CHECK: mov    disp, disp+2    ; encoding: [0x90,0x40,A,A,B,B]
 ; CHECK:                        ;   fixup A - offset: 2, value: disp, kind: fixup_16_pcrel_byte
 ; CHECK:                        ;   fixup B - offset: 4, value: disp+2, kind: fixup_16_pcrel_byte
+; RELOC: R_MSP430_16_PCREL_BYTE disp 0x0
+; RELOC: R_MSP430_16_PCREL_BYTE disp 0x2
 
          jmp    foo
 ; CHECK: jmp    foo             ; encoding: [A,0b001111AA]
 ; CHECK:                        ;   fixup A - offset: 0, value: foo, kind: fixup_10_pcrel
+; RELOC: R_MSP430_10_PCREL foo 0x0
+
+.short  _ctype+2
+; RELOC: R_MSP430_16_BYTE _ctype 0x2


### PR DESCRIPTION
Linker fails to link example like this (simplified case from newlib
sources):

$ cat test.c

  extern const char _ctype_b[];
  struct _t { char *ptr; };
  struct _t T = { ((char *) _ctype_b + 3) };

$ cat ctype.c
  char _ctype_b[4] = { 0, 0, 0, 0 };

LLD:    test.c:(.data+0x0): invalid value in R_MSP430_16
GNU LD: test.o:(.data+0x0): warning: internal error: unsupported relocation error

We also follow gnu toolchain here, where 2-byte relocation mapped to
R_MSP430_16_BYTE, instead of R_MSP320_16.
Fixes #36 