### PR TITLE
[MSP430] Fix crash while lowering llvm.stacksave() and llvm.stackrestore()

### DIFF
--- a/src/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
+++ b/src/llvm/lib/Target/MSP430/MSP430ISelLowering.cpp
@@ -95,6 +95,8 @@ MSP430TargetLowering::MSP430TargetLowering(const TargetMachine &TM,
   setOperationAction(ISD::SIGN_EXTEND,      MVT::i16,   Custom);
   setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i8, Expand);
   setOperationAction(ISD::DYNAMIC_STACKALLOC, MVT::i16, Expand);
+  setOperationAction(ISD::STACKSAVE,        MVT::Other, Expand);
+  setOperationAction(ISD::STACKRESTORE,     MVT::Other, Expand);
 
   setOperationAction(ISD::CTTZ,             MVT::i8,    Expand);
   setOperationAction(ISD::CTTZ,             MVT::i16,   Expand);

--- a/src/llvm/test/CodeGen/MSP430/stacksave_store.ll
+++ b/src/llvm/test/CodeGen/MSP430/stacksave_store.ll
@@ -1,0 +1,13 @@
+; RUN: llc < %s -march=msp430
+
+target triple = "msp430"
+
+define void @foo() #0 {
+entry:
+  %0 = tail call i8* @llvm.stacksave()
+  tail call void @llvm.stackrestore(i8* %0)
+  ret void
+}
+
+declare i8* @llvm.stacksave() #1
+declare void @llvm.stackrestore(i8*) #1


### PR DESCRIPTION
Fixes #43 