### PR TITLE
Do not use frame pointer by default, exactly as it's specified in the platform docs

### DIFF
--- a/src/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/src/llvm/tools/clang/lib/Driver/ToolChains/Clang.cpp
@@ -516,10 +516,10 @@ static bool useFramePointerForTargetByDefault(const ArgList &Args,
   case llvm::Triple::xcore:
   case llvm::Triple::wasm32:
   case llvm::Triple::wasm64:
+  case llvm::Triple::msp430:
     // XCore never wants frame pointers, regardless of OS.
     // WebAssembly never wants frame pointers.
     return false;
-  case llvm::Triple::msp430:
   case llvm::Triple::riscv32:
   case llvm::Triple::riscv64:
     return !areOptimizationsEnabled(Args);


### PR DESCRIPTION
@asl Anton, could you please kindly supersede #20 with this patch. Basically, it has been revealed that MSP430 code shall not use the frame pointer (not only when optimization if off as done in #20). The platform doc states the following:

```
3.3.9 Frame Pointer
MSP430 does not use a frame pointer. This effectively limits a single call frame to 0x7fff bytes, which is the minimum SP offset supported by any instruction
```
Interestingly, newest TI GCC as of today does not fully conform, making a special case of _exceptions enabled on MSP430_:

```
if (flag_exceptions || flag_non_call_exceptions
     || flag_unwind_tables || flag_asynchronous_unwind_tables)
   flag_omit_frame_pointer = false;
 else
   flag_omit_frame_pointer = true;
```

At this time, we disable frame pointer always by default, leaving user an option to alter this behavior.