### PR TITLE
[MSP430][Disassembler] Don't try to decode instructions that have size more than a number of input bytes

### DIFF
--- a/src/llvm/lib/Target/MSP430/Disassembler/MSP430Disassembler.cpp
+++ b/src/llvm/lib/Target/MSP430/Disassembler/MSP430Disassembler.cpp
@@ -249,6 +249,10 @@ DecodeStatus MSP430Disassembler::getInstructionI(MCInst &MI, uint64_t &Size,
   case amSymbolic:
   case amImmediate:
   case amAbsolute:
+    if (Bytes.size() < (Words + 1) * 2) {
+      Size = 2;
+      return DecodeStatus::Fail;
+    }
     Insn |= (uint64_t)support::endian::read16le(Bytes.data() + 2) << 16;
     ++Words;
     break;
@@ -259,6 +263,10 @@ DecodeStatus MSP430Disassembler::getInstructionI(MCInst &MI, uint64_t &Size,
   case amIndexed:
   case amSymbolic:
   case amAbsolute:
+    if (Bytes.size() < (Words + 1) * 2) {
+      Size = 2;
+      return DecodeStatus::Fail;
+    }
     Insn |= (uint64_t)support::endian::read16le(Bytes.data() + Words * 2)
         << (Words * 16);
     ++Words;
@@ -296,6 +304,10 @@ DecodeStatus MSP430Disassembler::getInstructionII(MCInst &MI, uint64_t &Size,
   case amSymbolic:
   case amImmediate:
   case amAbsolute:
+    if (Bytes.size() < (Words + 1) * 2) {
+      Size = 2;
+      return DecodeStatus::Fail;
+    }
     Insn |= (uint64_t)support::endian::read16le(Bytes.data() + 2) << 16;
     ++Words;
     break;

--- a/src/llvm/test/MC/Disassembler/MSP430/unknown.txt
+++ b/src/llvm/test/MC/Disassembler/MSP430/unknown.txt
@@ -1,0 +1,13 @@
+# RUN: not llvm-mc -disassemble -triple=msp430 %s 2>&1 | FileCheck %s
+
+# This should not decode as 'and.b @r15+, (0)r1' [0xf1,0xff,0x00,0x00]
+[0xf1 0xff]
+# CHECK: warning: invalid instruction encoding
+
+# This should not decode as 'add 6(r7), 6(r5)' [0x95 0x57 0x06 0x00 0x06 0x00]
+[0x95 0x57 0x06 0x00]
+# CHECK: warning: invalid instruction encoding
+
+# This should not decode as 'call 6(r7)' [0x97 0x12 0x06 0x00]
+[0x97 0x12]
+# CHECK: warning: invalid instruction encoding


### PR DESCRIPTION
Fixes #63 