### PR TITLE
Fix ubsan warning

### DIFF
--- a/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp
+++ b/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp
@@ -128,7 +128,7 @@ unsigned MSP430MCCodeEmitter::getMemOpValue(const MCInst &MI, unsigned Op,
   const MCOperand &MO2 = MI.getOperand(Op + 1);
   if (MO2.isImm()) {
     Offset += 2;
-    return (MO2.getImm() << 4) | Reg;
+    return ((unsigned)MO2.getImm() << 4) | Reg;
   }
 
   assert(MO2.isExpr() && "Expr operand expected");


### PR DESCRIPTION
Fix a failure when clang is built with -DLLVM_USE_SANITIZER="Address;Undefined"
```
msp430-clang/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp:131:26: runtime error: left shift of negative value -4
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior msp430-clang/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCCodeEmitter.cpp:131:26
```