### PR TITLE
Disable PIC/PIE for MSP430

### DIFF
--- a/src/llvm/tools/clang/lib/Driver/ToolChains/MSP430.h
+++ b/src/llvm/tools/clang/lib/Driver/ToolChains/MSP430.h
@@ -37,6 +37,10 @@ public:
                              llvm::opt::ArgStringList &CC1Args,
                              Action::OffloadKind) const override;
 
+  bool isPICDefault() const override { return false; }
+  bool isPIEDefault() const override { return false; }
+  bool isPICDefaultForced() const override { return true; }
+
 protected:
   Tool *buildLinker() const override;
 


### PR DESCRIPTION
I've verified that -shared is already ignored, so PIC/PIE settings is the only thing to disable. This fixes https://github.com/access-softek/msp430-clang/issues/72