### PR TITLE
[MSP430] Recoginze '{' as a line separator

### DIFF
--- a/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
+++ b/src/llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCAsmInfo.cpp
@@ -20,6 +20,7 @@ MSP430MCAsmInfo::MSP430MCAsmInfo(const Triple &TT) {
   CodePointerSize = CalleeSaveStackSlotSize = 2;
 
   CommentString = ";";
+  SeparatorString = "{";
 
   AlignmentIsInBytes = false;
   UsesELFSectionDirectiveForBSS = true;

--- a/src/llvm/test/MC/MSP430/msp430-separator.s
+++ b/src/llvm/test/MC/MSP430/msp430-separator.s
@@ -1,0 +1,15 @@
+; RUN: llvm-mc -triple msp430 < %s | FileCheck %s
+
+; MSP430 supports multiple assembly statements on the same line
+; separated by a '{' character.
+
+; Check that the '{' is recognized as a line separator and
+; multiple statements correctly parsed.
+
+_foo:
+; CHECK:      foo
+; CHECK:      add r10, r11
+; CHECK-NEXT: call r11
+; CHECK-NEXT: mov r11, 2(r1)
+add r10, r11 { call r11 { mov r11, 2(r1)
+ret


### PR DESCRIPTION
Resolves #58