### PR TITLE
[MSP430] Fix absolute addressing mode printing in AsmPrinter

### DIFF
--- a/src/llvm/lib/Target/MSP430/MSP430AsmPrinter.cpp
+++ b/src/llvm/lib/Target/MSP430/MSP430AsmPrinter.cpp
@@ -108,12 +108,12 @@ void MSP430AsmPrinter::printSrcMemOperand(const MachineInstr *MI, int OpNum,
   // Print displacement first
 
   // Imm here is in fact global address - print extra modifier.
-  if (Disp.isImm() && !Base.getReg())
+  if (Disp.isImm() && Base.getReg() == MSP430::SR)
     O << '&';
   printOperand(MI, OpNum+1, O, "nohash");
 
   // Print register base field
-  if (Base.getReg()) {
+  if (Base.getReg() != MSP430::SR && Base.getReg() != MSP430::PC) {
     O << '(';
     printOperand(MI, OpNum, O);
     O << ')';

--- a/src/llvm/test/CodeGen/MSP430/inline-asm-absolute-addressing.ll
+++ b/src/llvm/test/CodeGen/MSP430/inline-asm-absolute-addressing.ll
@@ -1,0 +1,15 @@
+; RUN: llc < %s | FileCheck %s
+
+; Check that absolute addressing mode is represented in a way
+; defined in MSP430 EABI and not as indexed addressing mode form.
+; See PR39993 for details.
+
+target datalayout = "e-p:16:8:8-i8:8:8-i16:8:8-i32:8:8-n8:16"
+target triple = "msp430-elf"
+
+define void @f() {
+entry:
+; CHECK: mov r1, &256
+  call void asm sideeffect "mov r1, $0", "*m"(i8* inttoptr (i16 256 to i8*))
+  ret void
+}


### PR DESCRIPTION
Align checks for absolute addressing mode with its current
implementation (SR is used as a base register).
It fixes https://bugs.llvm.org/show_bug.cgi?id=39993 and #75 