### PR TITLE
Pattern matching for indirect register addressing

### DIFF
--- a/src/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
+++ b/src/llvm/lib/Target/MSP430/MSP430ISelDAGToDAG.cpp
@@ -121,6 +121,7 @@ namespace {
                          unsigned Opc16);
 
     bool SelectAddr(SDValue Addr, SDValue &Base, SDValue &Disp);
+    bool SelectIndirectReg(SDValue N, SDValue &Base);
   };
 }  // end anonymous namespace
 
@@ -240,6 +241,16 @@ bool MSP430DAGToDAGISel::MatchAddress(SDValue N, MSP430ISelAddressMode &AM) {
   }
 
   return MatchAddressBase(N, AM);
+}
+
+/// SelectIndirectReg - returns true if it is able to match indirect register
+/// addressing mode. It returns base register by reference.
+bool MSP430DAGToDAGISel::SelectIndirectReg(SDValue N, SDValue &Base) {
+  if (N.getOpcode() == ISD::CopyFromReg) {
+    Base = N;
+    return true;
+  }
+  return false;
 }
 
 /// SelectAddr - returns true if it is able pattern match an addressing mode.

--- a/src/llvm/lib/Target/MSP430/MSP430InstrInfo.td
+++ b/src/llvm/lib/Target/MSP430/MSP430InstrInfo.td
@@ -154,6 +154,7 @@ def cg16imm : Operand<i16>,
 //===----------------------------------------------------------------------===//
 
 def addr : ComplexPattern<iPTR, 2, "SelectAddr", [], []>;
+def addrIndReg : ComplexPattern<iPTR, 1, "SelectIndirectReg", [], [], 10>;
 
 //===----------------------------------------------------------------------===//
 // Pattern Fragments
@@ -288,11 +289,9 @@ let isCall = 1,
   def CALLr     : II16r<0b101,
                         (outs), (ins GR16:$rs),
                         "call\t$rs", [(MSP430call GR16:$rs)]>;
-  def CALLm     : II16m<0b101,
-                        (outs), (ins memsrc:$src),
-                        "call\t$src", [(MSP430call (load addr:$src))]>;
-  def CALLn     : II16n<0b101, (outs), (ins indreg:$rs), "call\t$rs", []>;
-  def CALLp     : II16p<0b101, (outs), (ins postreg:$rs), "call\t$rs", []>;
+  def CALLm     : II16m<0b101, (outs), (ins memsrc:$src), "call\t$src", []>;
+  def CALLn     : II16n<0b101, (outs), (ins indreg:$rs),  "call\t$rs",  []>;
+  def CALLp     : II16p<0b101, (outs), (ins postreg:$rs), "call\t$rs",  []>;
 }
 
 //===----------------------------------------------------------------------===//
@@ -358,11 +357,11 @@ def MOV16rm : I16rm<0b0100,
 def MOV8rn  : I8rn<0b0100,
                    (outs GR8:$rd), (ins indreg:$rs),
                    "mov.b\t{$rs, $rd}",
-                   [(set GR8:$rd, (load addr:$rs))]>;
+                   [(set GR8:$rd, (load addrIndReg:$rs))]>;
 def MOV16rn : I16rn<0b0100,
                     (outs GR16:$rd), (ins indreg:$rs),
                     "mov\t{$rs, $rd}",
-                    [(set GR16:$rd, (load addr:$rs))]>;
+                    [(set GR16:$rd, (load addrIndReg:$rs))]>;
 }
 
 let isCodeGenOnly = 1 in {
@@ -374,6 +373,10 @@ def MOVZX16rm8 : I8rm<0b0100,
                       (outs GR16:$rd), (ins memsrc:$src),
                       "mov.b\t{$src, $rd}",
                       [(set GR16:$rd, (zextloadi16i8 addr:$src))]>;
+def MOVZX16rn8 : I8rn<0b0100,
+                      (outs GR16:$rd), (ins indreg:$rs),
+                      "mov.b\t{$rs, $rd}",
+                      [(set GR16:$rd, (zextloadi16i8 addrIndReg:$rs))]>;
 }
 
 let mayLoad = 1, hasExtraDefRegAllocReq = 1, Constraints = "$rs = $wb" in {
@@ -437,9 +440,11 @@ def MOV16mm : I16mm<0b0100,
                     [(store (i16 (load addr:$src)), addr:$dst)]>;
 
 def MOV8mn  : I8mn<0b0100, (outs), (ins memdst:$dst, indreg:$rs),
-                   "mov.b\t{$rs, $dst}", []>;
+                   "mov.b\t{$rs, $dst}",
+                    [(store (i8 (load addrIndReg:$rs)), addr:$dst)]>;
 def MOV16mn : I16mn<0b0100, (outs), (ins memdst:$dst, indreg:$rs),
-                    "mov\t{$rs, $dst}", []>;
+                    "mov\t{$rs, $dst}",
+                    [(store (i16 (load addrIndReg:$rs)), addr:$dst)]>;
 
 //===----------------------------------------------------------------------===//
 // Arithmetic Instructions
@@ -467,9 +472,13 @@ multiclass Arith<bits<4> opcode, string asmstring, SDNode node,
                    [(set GR16:$rd, (node GR16:$src2, (load addr:$src))),
                     (implicit SR)]>;
   def 8rn : I8rn<opcode, (outs GR8:$rd), (ins GR8:$src2, indreg:$rs),
-                 !strconcat(asmstring, ".b\t$rs, $rd"), []>;
+                 !strconcat(asmstring, ".b\t$rs, $rd"),
+                 [(set GR8:$rd, (node GR8:$src2, (load addrIndReg:$rs))),
+                  (implicit SR)]>;
   def 16rn : I16rn<opcode, (outs GR16:$rd), (ins GR16:$src2, indreg:$rs),
-                   !strconcat(asmstring, "\t$rs, $rd"), []>;
+                   !strconcat(asmstring, "\t$rs, $rd"),
+                   [(set GR16:$rd, (node GR16:$src2, (load addrIndReg:$rs))),
+                    (implicit SR)]>;
   let mayLoad = 1,
       hasExtraDefRegAllocReq = 1,
       Constraints = "$rs = $wb, $src2 = $rd" in {
@@ -521,18 +530,24 @@ multiclass Arith<bits<4> opcode, string asmstring, SDNode node,
                     (implicit SR)]>;
   def 8mm : I8mm<opcode, (outs), (ins memdst:$dst, memsrc:$src),
                  !strconcat(asmstring, ".b\t$src, $dst"),
-                 [(store (node (load addr:$dst), 
+                 [(store (node (load addr:$dst),
                                (i8 (load addr:$src))), addr:$dst),
                   (implicit SR)]>;
   def 16mm : I16mm<opcode, (outs), (ins memdst:$dst, memsrc:$src),
                    !strconcat(asmstring, "\t$src, $dst"),
-                   [(store (node (load addr:$dst), 
+                   [(store (node (load addr:$dst),
                                  (i16 (load addr:$src))), addr:$dst),
                     (implicit SR)]>;
   def 8mn : I8mn<opcode, (outs), (ins memdst:$dst, indreg:$rs),
-                 !strconcat(asmstring, ".b\t$rs, $dst"), []>;
+                 !strconcat(asmstring, ".b\t$rs, $dst"),
+                 [(store (node (load addr:$dst),
+                               (i8 (load addrIndReg:$rs))), addr:$dst),
+                  (implicit SR)]>;
   def 16mn : I16mn<opcode, (outs), (ins memdst:$dst, indreg:$rs),
-                   !strconcat(asmstring, "\t$rs, $dst"), []>;
+                   !strconcat(asmstring, "\t$rs, $dst"),
+                   [(store (node (load addr:$dst),
+                                 (i16 (load addrIndReg:$rs))), addr:$dst),
+                    (implicit SR)]>;
   def 8mp : I8mp<opcode, (outs), (ins memdst:$dst, postreg:$rs),
                  !strconcat(asmstring, ".b\t$rs, $dst"), []>;
   def 16mp : I16mp<opcode, (outs), (ins memdst:$dst, postreg:$rs),
@@ -685,9 +700,14 @@ def RRA16m : II16m<0b010,
                    "rra\t$src",
                    [(store (MSP430rra (i16 (load addr:$src))), addr:$src),
                     (implicit SR)]>;
-
-def RRA8n  : II8n<0b010, (outs), (ins indreg:$rs), "rra.b\t$rs", []>;
-def RRA16n : II16n<0b010, (outs), (ins indreg:$rs), "rra\t$rs", []>;
+def RRA8n  : II8n<0b010, (outs), (ins indreg:$rs), "rra.b\t$rs",
+                  [(store
+                   (MSP430rra (i8 (load addrIndReg:$rs))), addrIndReg:$rs),
+                   (implicit SR)]>;
+def RRA16n : II16n<0b010, (outs), (ins indreg:$rs), "rra\t$rs",
+                   [(store
+                    (MSP430rra (i16 (load addrIndReg:$rs))), addrIndReg:$rs),
+                    (implicit SR)]>;
 def RRA8p  : II8p<0b010, (outs), (ins postreg:$rs), "rra.b\t$rs", []>;
 def RRA16p : II16p<0b010, (outs), (ins postreg:$rs), "rra\t$rs", []>;
 
@@ -703,8 +723,16 @@ def RRC16m : II16m<0b000,
                    [(store (MSP430rrc (i16 (load addr:$src))), addr:$src),
                     (implicit SR)]>;
 
-def RRC8n  : II8n<0b000, (outs), (ins indreg:$rs), "rrc.b\t$rs", []>;
-def RRC16n : II16n<0b000, (outs), (ins indreg:$rs), "rrc\t$rs", []>;
+def RRC8n  : II8n<0b000, (outs), (ins indreg:$rs),
+                  "rrc.b\t$rs",
+                  [(store
+                   (MSP430rrc (i8 (load addrIndReg:$rs))), addrIndReg:$rs),
+                   (implicit SR)]>;
+def RRC16n : II16n<0b000, (outs), (ins indreg:$rs),
+                   "rrc\t$rs",
+                   [(store
+                    (MSP430rrc (i16 (load addrIndReg:$rs))), addrIndReg:$rs),
+                    (implicit SR)]>;
 def RRC8p  : II8p<0b000, (outs), (ins postreg:$rs), "rrc.b\t$rs", []>;
 def RRC16p : II16p<0b000, (outs), (ins postreg:$rs), "rrc\t$rs", []>;
 
@@ -716,7 +744,10 @@ def SEXT16m : II16m<0b011,
                     [(store (sext_inreg (extloadi16i8 addr:$src), i8),
                              addr:$src),
                      (implicit SR)]>;
-def SEXT16n : II16n<0b011, (outs), (ins indreg:$rs), "sxt\t$rs", []>;
+def SEXT16n : II16n<0b011, (outs), (ins indreg:$rs), "sxt\t$rs",
+                    [(store (sext_inreg (extloadi16i8 addrIndReg:$rs), i8),
+                            addrIndReg:$rs),
+                     (implicit SR)]>;
 def SEXT16p : II16p<0b011, (outs), (ins postreg:$rs), "sxt\t$rs", []>;
 
 } // Defs = [SR]
@@ -725,7 +756,9 @@ def SWPB16m : II16m<0b001,
                    (outs), (ins memsrc:$src),
                    "swpb\t$src",
                    [(store (bswap (i16 (load addr:$src))), addr:$src)]>;
-def SWPB16n : II16n<0b001, (outs), (ins indreg:$rs), "swpb\t$rs", []>;
+def SWPB16n : II16n<0b001, (outs), (ins indreg:$rs), "swpb\t$rs",
+                   [(store
+                    (bswap (i16 (load addrIndReg:$rs))), addrIndReg:$rs)]>;
 def SWPB16p : II16p<0b001, (outs), (ins postreg:$rs), "swpb\t$rs", []>;
 
 // Integer comparisons
@@ -791,9 +824,15 @@ def CMP16rm : I16rm<0b1001,
                      (implicit SR)]>;
 
 def CMP8rn  : I8rn<0b1001,
-                   (outs), (ins GR8:$rd, indreg:$rs), "cmp.b\t$rs, $rd", []>;
+                   (outs), (ins GR8:$rd, indreg:$rs),
+                   "cmp.b\t$rs, $rd",
+                   [(MSP430cmp GR8:$rd, (load addrIndReg:$rs)),
+                    (implicit SR)]>;
 def CMP16rn : I16rn<0b1001,
-                    (outs), (ins GR16:$rd, indreg:$rs), "cmp\t$rs, $rd", []>;
+                    (outs), (ins GR16:$rd, indreg:$rs),
+                    "cmp\t$rs, $rd",
+                    [(MSP430cmp GR16:$rd, (load addrIndReg:$rs)),
+                     (implicit SR)]>;
 
 def CMP8rp  : I8rp<0b1001,
                    (outs), (ins GR8:$rd, postreg:$rs), "cmp.b\t$rs, $rd", []>;
@@ -820,10 +859,16 @@ def CMP16mm : I16mm<0b1001, (outs), (ins memdst:$dst, memsrc:$src),
                     [(MSP430cmp (load addr:$dst), (i16 (load addr:$src))),
                      (implicit SR)]>;
 
-def CMP8mn  : I8mn<0b1001, (outs), (ins memsrc:$dst, indreg:$rs),
-                   "cmp.b\t$rs, $dst", []>;
-def CMP16mn : I16mn<0b1001, (outs), (ins memsrc:$dst, indreg:$rs),
-                    "cmp\t$rs, $dst", []>;
+def CMP8mn  : I8mn<0b1001,
+                   (outs), (ins memsrc:$dst, indreg:$rs),
+                   "cmp.b\t$rs, $dst",
+                   [(MSP430cmp (load addr:$dst), (i8 (load addrIndReg:$rs))),
+                    (implicit SR)]>;
+def CMP16mn : I16mn<0b1001,
+                    (outs), (ins memsrc:$dst, indreg:$rs),
+                    "cmp\t$rs, $dst",
+                    [(MSP430cmp (load addr:$dst), (i16 (load addrIndReg:$rs))),
+                    (implicit SR)]>;
 
 def CMP8mp  : I8mp<0b1001, (outs), (ins memsrc:$dst, postreg:$rs),
                    "cmp.b\t$rs, $dst", []>;
@@ -877,10 +922,16 @@ def BIT16rm : I16rm<0b1011,
                     [(MSP430cmp (and_su GR16:$rd,  (load addr:$src)), 0),
                      (implicit SR)]>;
 
-def BIT8rn  : I8rn<0b1011, (outs), (ins GR8:$rd, indreg:$rs),
-                   "bit.b\t$rs, $rd", []>;
-def BIT16rn : I16rn<0b1011, (outs), (ins GR16:$rd, indreg:$rs),
-                    "bit\t$rs, $rd", []>;
+def BIT8rn  : I8rn<0b1011,
+                   (outs), (ins GR8:$rd, indreg:$rs),
+                   "bit.b\t$rs, $rd",
+                   [(MSP430cmp (and_su GR8:$rd, (load addrIndReg:$rs)), 0),
+                    (implicit SR)]>;
+def BIT16rn : I16rn<0b1011,
+                    (outs), (ins GR16:$rd, indreg:$rs),
+                    "bit\t$rs, $rd",
+                    [(MSP430cmp (and_su GR16:$rd, (load addrIndReg:$rs)), 0),
+                     (implicit SR)]>;
 
 def BIT8rp  : I8rp<0b1011, (outs), (ins GR8:$rd, postreg:$rs),
                    "bit.b\t$rs, $rd", []>;
@@ -935,9 +986,17 @@ def BIT16mm : I16mm<0b1011,
                                  0),
                      (implicit SR)]>;
 def BIT8mn  : I8mn<0b1011, (outs), (ins memsrc:$dst, indreg:$rs),
-                   "bit.b\t$rs, $dst", []>;
+                   "bit.b\t$rs, $dst",
+                    [(MSP430cmp (and_su (i8 (load addr:$dst)),
+                                        (load addrIndReg:$rs)),
+                                 0),
+                     (implicit SR)]>;
 def BIT16mn : I16mn<0b1011, (outs), (ins memsrc:$dst, indreg:$rs),
-                    "bit\t$rs, $dst", []>;
+                    "bit\t$rs, $dst",
+                    [(MSP430cmp (and_su (i16 (load addr:$dst)),
+                                        (load addrIndReg:$rs)),
+                                 0),
+                     (implicit SR)]>;
 
 def BIT8mp  : I8mp<0b1011, (outs), (ins memsrc:$dst, postreg:$rs),
                    "bit.b\t$rs, $dst", []>;
@@ -956,6 +1015,7 @@ def TST16m  : InstAlias<"tst\t$dst",    (CMP16mc   memdst:$dst,  0)>;
 
 // extload
 def : Pat<(extloadi16i8 addr:$src), (MOVZX16rm8 addr:$src)>;
+def : Pat<(extloadi16i8 addrIndReg:$rs), (MOVZX16rn8 addrIndReg:$rs)>;
 
 // anyext
 def : Pat<(i16 (anyext GR8:$src)),

--- a/src/llvm/test/CodeGen/MSP430/indreg.ll
+++ b/src/llvm/test/CodeGen/MSP430/indreg.ll
@@ -1,0 +1,327 @@
+; RUN: llc < %s --show-mc-encoding | FileCheck %s
+target datalayout = "e-m:e-p:16:16-i32:16-i64:16-f32:16-f64:16-a:8-n8:16-S16"
+target triple = "msp430-elf"
+
+define i8 @mov8rn(i8* nocapture readonly %a) {
+entry:
+; CHECK-LABEL: mov8rn:
+; CHECK: mov.b @r12, r12 ; encoding: [0x6c,0x4c]
+
+  %0 = load i8, i8* %a, align 1
+  ret i8 %0
+}
+define i16 @mov16rn(i16* nocapture readonly %a) {
+entry:
+; CHECK-LABEL: mov16rn:
+; CHECK: mov @r12, r12   ; encoding: [0x2c,0x4c]
+
+  %0 = load i16, i16* %a, align 2
+  ret i16 %0
+}
+define void @mov8mn(i8* %g, i8* %i) {
+entry:
+; CHECK-LABEL: mov8mn:
+; CHECK: mov.b @r13, @r12 ; encoding: [0xec,0x4d,0x00,0x00]
+
+  %0 = load i8, i8* %i, align 1
+  store i8 %0, i8* %g, align 1
+  ret void
+}
+define void @mov16mn(i16* %g, i16* %i) {
+entry:
+; CHECK-LABEL: mov16mn:
+; CHECK: mov @r13, @r12  ; encoding: [0xac,0x4d,0x00,0x00]
+
+  %0 = load i16, i16* %i, align 2
+  store i16 %0, i16* %g, align 2
+  ret void
+}
+
+define i8 @bis8rn(i8 %x, i8* %a) nounwind {
+; CHECK-LABEL: bis8rn:
+; CHECK: bis.b @r13, r12 ; encoding: [0x6c,0xdd]
+
+  %1 = load i8, i8* %a
+  %2 = or i8 %1,%x
+  ret i8 %2
+}
+define i16 @bis16rn(i16 %x, i16* %a) nounwind {
+; CHECK-LABEL: bis16rn:
+; CHECK: bis @r13, r12 ; encoding: [0x2c,0xdd]
+
+  %1 = load i16, i16* %a
+  %2 = or i16 %1,%x
+  ret i16 %2
+}
+define void @bis8mn(i8* %x, i8* %a) nounwind {
+; CHECK-LABEL: bis8mn:
+; CHECK: bis.b @r13, @r12 ; encoding: [0xec,0xdd,0x00,0x00]
+
+  %1 = load i8, i8* %x
+  %2 = load i8, i8* %a
+  %3 = or i8 %1,%2
+  store i8 %3, i8* %x, align 2
+  ret void
+}
+define void @bis16mn(i16* %x, i16* %a) nounwind {
+; CHECK-LABEL: bis16mn:
+; CHECK: bis @r13, @r12 ; encoding: [0xac,0xdd,0x00,0x00]
+
+  %1 = load i16, i16* %x
+  %2 = load i16, i16* %a
+  %3 = or i16 %1,%2
+  store i16 %3, i16* %x, align 2
+  ret void
+}
+
+define i8 @add8rn(i8 %x, i8* %a) nounwind {
+; CHECK-LABEL: add8rn:
+; CHECK: add.b @r13, r12 ; encoding: [0x6c,0x5d]
+  %1 = load i8, i8* %a
+  %2 = add i8 %1,%x
+  ret i8 %2
+}
+define i16 @add16rn(i16 %x, i16* %a) nounwind {
+; CHECK-LABEL: add16rn:
+; CHECK: add @r13, r12   ; encoding: [0x2c,0x5d]
+  %1 = load i16, i16* %a
+  %2 = add i16 %1,%x
+  ret i16 %2
+}
+define void @add8mn(i8* %x, i8* %a) nounwind {
+; CHECK-LABEL: add8mn:
+; CHECK: add.b @r13, @r12 ; encoding: [0xec,0x5d,0x00,0x00]
+
+  %1 = load i8, i8* %x
+  %2 = load i8, i8* %a
+  %3 = add i8 %2, %1
+  store i8 %3, i8* %x
+  ret void
+}
+define void @add16mn(i16* %x, i16* %a) nounwind {
+; CHECK-LABEL: add16mn:
+; CHECK: add @r13, @r12   ; encoding: [0xac,0x5d,0x00,0x00]
+
+  %1 = load i16, i16* %x
+  %2 = load i16, i16* %a
+  %3 = add i16 %2, %1
+  store i16 %3, i16* %x
+  ret void
+}
+
+define i8 @and8rn(i8 %x, i8* %a) nounwind {
+; CHECK-LABEL: and8rn:
+; CHECK: and.b @r13, r12 ; encoding: [0x6c,0xfd]
+
+  %1 = load i8, i8* %a
+  %2 = and i8 %1,%x
+  ret i8 %2
+}
+define i16 @and16rn(i16 %x, i16* %a) nounwind {
+; CHECK-LABEL: and16rn:
+; CHECK: and @r13, r12   ; encoding: [0x2c,0xfd]
+
+  %1 = load i16, i16* %a
+  %2 = and i16 %1,%x
+  ret i16 %2
+}
+define void @and8mn(i8* %x, i8* %a) nounwind {
+; CHECK-LABEL: and8mn:
+; CHECK: and.b @r13, @r12 ; encoding: [0xec,0xfd,0x00,0x00]
+
+  %1 = load i8, i8* %x
+  %2 = load i8, i8* %a
+	%3 = and i8 %2, %1
+	store i8 %3, i8* %x
+	ret void
+}
+define void @and16mn(i16* %x, i16* %a) nounwind {
+; CHECK-LABEL: and16mn:
+; CHECK: and @r13, @r12   ; encoding: [0xac,0xfd,0x00,0x00]
+
+  %1 = load i16, i16* %x
+  %2 = load i16, i16* %a
+	%3 = and i16 %2, %1
+	store i16 %3, i16* %x
+	ret void
+}
+
+define i8 @xor8rn(i8 %x, i8* %a) nounwind {
+; CHECK-LABEL: xor8rn:
+; CHECK: xor.b @r13, r12 ; encoding: [0x6c,0xed]
+
+  %1 = load i8, i8* %a
+  %2 = xor i8 %1,%x
+  ret i8 %2
+}
+define i16 @xor16rn(i16 %x, i16* %a) nounwind {
+; CHECK-LABEL: xor16rn:
+; CHECK: xor @r13, r12  ; encoding: [0x2c,0xed]
+
+  %1 = load i16, i16* %a
+  %2 = xor i16 %1,%x
+  ret i16 %2
+}
+define void @xor8mn(i8* %x, i8* %a) nounwind {
+; CHECK-LABEL: xor8mn:
+; CHECK: xor.b @r13, @r12 ; encoding: [0xec,0xed,0x00,0x00]
+
+  %1 = load i8, i8* %x
+  %2 = load i8, i8* %a
+	%3 = xor i8 %2, %1
+	store i8 %3, i8* %x
+	ret void
+}
+define void @xor16mn(i16* %x, i16* %a) nounwind {
+; CHECK-LABEL: xor16mn:
+; CHECK: xor @r13, @r12  ; encoding: [0xac,0xed,0x00,0x00]
+
+  %1 = load i16, i16* %x
+  %2 = load i16, i16* %a
+	%3 = xor i16 %2, %1
+	store i16 %3, i16* %x
+	ret void
+}
+
+define void @cmp8rn(i8* %g, i8 %i) {
+entry:
+; CHECK-LABEL: cmp8rn:
+; CHECK: cmp.b @r12, r13  ; encoding: [0x6d,0x9c]
+
+  %0 = load i8, i8* %g, align 2
+  %cmp = icmp sgt i8 %0, %i
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  store i8 0, i8* %g, align 2
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  ret void
+}
+define void @cmp16rn(i16* %g, i16 %i) {
+entry:
+; CHECK-LABEL: cmp16rn:
+; CHECK: cmp @r12, r13    ; encoding: [0x2d,0x9c]
+
+  %0 = load i16, i16* %g, align 2
+  %cmp = icmp sgt i16 %0, %i
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  store i16 0, i16* %g, align 2
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  ret void
+}
+define void @cmp8mn(i8* %g, i8* %i) {
+entry:
+; CHECK-LABEL: cmp8mn:
+; CHECK: cmp.b @r12, @r13  ; encoding: [0xed,0x9c,0x00,0x00]
+
+  %0 = load i8, i8* %g, align 2
+  %1 = load i8, i8* %i, align 2
+  %cmp = icmp sgt i8 %0, %1
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  store i8 0, i8* %g, align 2
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  ret void
+}
+define void @cmp16mn(i16* %g, i16* %i) {
+entry:
+; CHECK-LABEL: cmp16mn:
+; CHECK: cmp @r12, @r13  ; encoding: [0xad,0x9c,0x00,0x00]
+
+  %0 = load i16, i16* %g, align 2
+  %1 = load i16, i16* %i, align 2
+  %cmp = icmp sgt i16 %0, %1
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %entry
+  store i16 0, i16* %g, align 2
+  br label %if.end
+
+if.end:                                           ; preds = %if.then, %entry
+  ret void
+}
+
+define i8 @bit8rn(i8 %a, i8* %b) {
+; CHECK-LABEL: bit8rn:
+; CHECK: bit.b @r13, r12  ; encoding: [0x6c,0xbd]
+
+  %1 = load i8, i8* %b
+  %2 = and i8 %a, %1
+  %3 = icmp ne i8 %2, 0
+  %4 = zext i1 %3 to i8
+  ret i8 %4
+}
+define i16 @bit16rn(i16 %a, i16* %b) {
+; CHECK-LABEL: bit16rn:
+; CHECK: bit @r13, r12    ; encoding: [0x2c,0xbd]
+
+  %1 = load i16, i16* %b
+  %2 = and i16 %a, %1
+  %3 = icmp ne i16 %2, 0
+  %4 = zext i1 %3 to i16
+  ret i16 %4
+}
+define i8 @bit8mn(i8* %a, i8* %b) {
+; CHECK-LABEL: bit8mn:
+; CHECK: bit.b @r13, @r12  ; encoding: [0xec,0xbd,0x00,0x00]
+
+  %1 = load i8, i8* %a
+  %2 = load i8, i8* %b
+  %3 = and i8 %1, %2
+  %4 = icmp ne i8 %3, 0
+  %5 = zext i1 %4 to i8
+  ret i8 %5
+}
+define i16 @bit16mn(i16* %a, i16* %b) {
+; CHECK-LABEL: bit16mn:
+; CHECK: bit @r13, @r12    ; encoding: [0xac,0xbd,0x00,0x00]
+
+  %1 = load i16, i16* %a
+  %2 = load i16, i16* %b
+  %3 = and i16 %1, %2
+  %4 = icmp ne i16 %3, 0
+  %5 = zext i1 %4 to i16
+  ret i16 %5
+}
+
+define void @rra8n(i8* %i) {
+entry:
+; CHECK-LABEL: rra8n:
+; CHECK: rra.b @r12 ; encoding: [0x6c,0x11]
+
+  %0 = load i8, i8* %i, align 1
+  %shr = ashr i8 %0, 1
+  store i8 %shr, i8* %i, align 1
+  ret void
+}
+define void @rra16n(i16* %i) {
+entry:
+; CHECK-LABEL: rra16n:
+; CHECK: rra @r12 ; encoding: [0x2c,0x11]
+
+  %0 = load i16, i16* %i, align 2
+  %shr = ashr i16 %0, 1
+  store i16 %shr, i16* %i, align 2
+  ret void
+}
+
+define void @sxt16n(i16* %x) {
+entry:
+; CHECK-LABEL: sxt16n:
+; CHECK: sxt @r12 ; encoding: [0xac,0x11]
+
+  %0 = bitcast i16* %x to i8*
+  %1 = load i8, i8* %0, align 1
+  %conv = sext i8 %1 to i16
+  store i16 %conv, i16* %x, align 2
+  ret void
+}


### PR DESCRIPTION
This is another implementation for emitting instructions in indirect register addressing mode (just note that indirect register addressing has 2 bytes less encoding than indexed one). 
First one was in #66. It provides an MI-level pass which rewrites mm|mr instructions where displacement == 0 to their nm|nr counterpart.
This one is more straightforward. It allows matching correct instruction form on ISel phase. The only drawback it has is that it doesn't work with SP base register. 

Will appreciate any feedback for this or/and #66 implementation.